### PR TITLE
add IPFS integration

### DIFF
--- a/src/lightning_hivemind/strategy.py
+++ b/src/lightning_hivemind/strategy.py
@@ -170,7 +170,7 @@ class HivemindStrategy(Strategy):
             initial_peers=initial_peers,
             host_maddrs=host_maddrs if host_maddrs is not None else ["/ip4/0.0.0.0/tcp/0", "/ip4/0.0.0.0/udp/0/quic"],
             use_ipfs=use_ipfs,
-            ensure_bootstrap_success=True if not use_ipfs else False,
+            ensure_bootstrap_success=bool(not use_ipfs),
         )
 
         visible_addresses = [

--- a/src/lightning_hivemind/strategy.py
+++ b/src/lightning_hivemind/strategy.py
@@ -105,6 +105,9 @@ class HivemindStrategy(Strategy):
         initial_peers: If connecting to a running process, a list of initial peers needs to be passed in.
             This can also be set via the env variable ``INITIAL_PEERS``.
 
+        use_ipfs: Use IPFS to find initial_peers. If enabled, you only need to provide /p2p/XXXX part of the
+            multiaddrs for the initial_peers (no need to specify a particular IPv4/IPv6 host and port)"
+
         **optimizer_kwargs: kwargs are passed to the :class:`hivemind.Optimizer` class.
     """
 
@@ -128,6 +131,7 @@ class HivemindStrategy(Strategy):
         averager_opts: Optional[Dict] = None,
         host_maddrs: Optional[List] = None,
         initial_peers: Optional[Union[str, List]] = None,
+        use_ipfs: bool = False,
         **optimizer_kwargs: Any,
     ):
         if platform.system() != "Linux":
@@ -165,6 +169,8 @@ class HivemindStrategy(Strategy):
             start=True,
             initial_peers=initial_peers,
             host_maddrs=host_maddrs if host_maddrs is not None else ["/ip4/0.0.0.0/tcp/0", "/ip4/0.0.0.0/udp/0/quic"],
+            use_ipfs=use_ipfs,
+            ensure_bootstrap_success=True if not use_ipfs else False,
         )
 
         visible_addresses = [


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

Implements the `use_ipfs` argument, [as documented here](https://learning-at-home.readthedocs.io/en/latest/user/dht.html).

IPFS nodes will not respond to ping in the way Hivemind expects, so we also set `ensure_bootstrap_success` to False, when IPFS is used. Nevertheless, HivemindStrategy will connect to peers successfully once training begins.