### PR TITLE
migrate to latest supported pydantic

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 numpy <2.0  # needed for older Torch
 torch <2.3  # fixme: freeze until AMP compatibility is resolved
 lightning >=2.0.0
-hivemind >=1.1.0, <=1.1.10.post2; sys_platform == 'linux'
+hivemind @ git+https://github.com/learning-at-home/hivemind.git@213bff98a62accb91f254e2afdccbf1d69ebdea9; sys_platform == 'linux'
 
-pydantic <2.0.0  # fixme: lift when resolved


### PR DESCRIPTION
## What does this PR do?

This PR lifts the `pydantic < 2.0` restriction. [Hivemind was recently updated to support Pydantic v2](https://github.com/learning-at-home/hivemind), and this limitation is no longer necessary. 

I'm not sure why, but maintainers are not releasing PyPi packages anymore. If you look at the [Petals source code](https://github.com/bigscience-workshop/petals/blob/main/setup.cfg#L42), you'll see that they just point to the appropriate commit hash on Github; so, that's what I've done here, as well.

Let me know if you have any questions. Thanks!